### PR TITLE
Fix broken zenodohome hyperlink

### DIFF
--- a/config.py
+++ b/config.py
@@ -21,7 +21,7 @@ front_page_cache = 600
 host = "http://url_goes_here.org"
 
 # Repository listing all DB dumps available for download:
-zenodohome = "doi.org/10.5281/zenodo.123456"
+zenodohome = "https://doi.org/10.5281/zenodo.123456"
 
 # Link to a form to provide feedback on the website
 feedback = ""


### PR DESCRIPTION
Currently, in https://rxivist.org/docs, the following sentence:
"The PostgreSQL dumps are available for direct download."
links to https://rxivist.org/doi.org/10.5281/zenodo.123456.